### PR TITLE
Added a .gitignore to not track cargo builds

### DIFF
--- a/core-server/.gitignore
+++ b/core-server/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/


### PR DESCRIPTION
git no longer tracks the `Cargo.lock` and `target/` files.